### PR TITLE
feat: create ddb record for new users and fix invoices

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -408,11 +408,16 @@ export default {
     if (this.$vuetify.breakpoint.lgAndUp) {
       this.isSidebarOpen = true
     }
+
+    this.checkUserRecordExists({
+      sub: this.profile.id
+    })
   },
 
   methods: {
     ...mapActions({
-      signOut: 'auth/signOut'
+      signOut: 'auth/signOut',
+      checkUserRecordExists: 'auth/checkUserRecordExists'
     }),
 
     onSidebarToggle () {

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -13,11 +13,7 @@ export default function ({ store, redirect, route }) {
   const meta = isArray(route.meta) &&
     route.meta.find(meta => isArray(meta.auth))
 
-  if (!meta) {
-    return
-  }
-
-  const { auth } = meta
+  const { auth } = meta || {}
 
   const loggedIn = store.getters['auth/isLoggedIn']
 
@@ -27,7 +23,7 @@ export default function ({ store, redirect, route }) {
   }
 
   // Allowed only for not authenticated users, but user is authenticated
-  if (auth.includes(authStatus.NOT_AUTHENTICATED) && loggedIn) {
+  if (auth && auth.includes(authStatus.NOT_AUTHENTICATED) && loggedIn) {
     return redirect(302, '/')
   }
 }

--- a/store/auth.js
+++ b/store/auth.js
@@ -1,4 +1,5 @@
 import { Auth } from 'aws-amplify'
+import AwsClient from '~/services/aws/AWSClient'
 
 const types = {
   AUTH_SET: 'AUTH_SET'
@@ -19,7 +20,9 @@ export const actions = {
     const user = await Auth.currentUserInfo()
 
     if (!user) {
-      return
+      return dispatch('setAuthState', {
+        isLoggedIn: false
+      })
     }
 
     await Promise.all([
@@ -39,6 +42,49 @@ export const actions = {
         key: user.attributes.sub
       }, { root: true })
     ])
+  },
+
+  async checkUserRecordExists (store, { sub }) {
+    const dbClient = await AwsClient.dynamoDb()
+    const { identityId } = await AwsClient.credentials()
+
+    const { Items } = await dbClient.query({
+      TableName: 'default',
+      KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :sk)',
+      ExpressionAttributeNames: {
+        '#pk': 'pk',
+        '#sk': 'sk',
+        '#sub': 'sub'
+      },
+      FilterExpression: '#sub = :sub',
+      ExpressionAttributeValues: {
+        ':pk': identityId,
+        ':sk': 'user#basic',
+        ':sub': sub
+      }
+    }).promise()
+
+    return Items?.length > 0
+  },
+
+  async createUserRecord (store, {
+    sub,
+    email
+  }) {
+    const dbClient = await AwsClient.dynamoDb()
+    const { identityId } = await AwsClient.credentials()
+
+    const documentPayload = {
+      pk: identityId,
+      sk: 'user#basic',
+      sub,
+      email
+    }
+
+    await dbClient.put({
+      TableName: 'default',
+      Item: documentPayload
+    }).promise()
   },
 
   setAuthState ({ commit }, { isLoggedIn = false }) {

--- a/store/invoices.js
+++ b/store/invoices.js
@@ -39,7 +39,7 @@ export const actions = {
       ...(startKey && {
         ExclusiveStartKey: startKey
       })
-    })
+    }).promise()
 
     if (LastEvaluatedKey) {
       // Store pagination key for the next page


### PR DESCRIPTION
- Create a record in DDB for every new user before showing dashboard
- Fix invoices not fetching
- Fix amplify authStateChange event handled twice

I've encountered an obstacle in implementation according to #63. Suggested method of manually handling UI form submission for confirm sign up (and others) doesn't seem to work, as suggested in documentation. This PR includes option 2: on successful sign in we query DDB by user id to check if `user#basic` table record exists. This is also the most reliable solution available on front-end for the task.

If additional DDB request is an issue, we can think of a way to store a custom field in user profile "setup_completed" or smth and make a check based on that field, instead of querying DDB.

Closes #63 