### PR TITLE
feat: #218 reduce app toolbar avatar size

### DIFF
--- a/components/general/AppToolbar/index.vue
+++ b/components/general/AppToolbar/index.vue
@@ -118,7 +118,7 @@
     </v-menu>
 
     <v-avatar
-      size="48"
+      size="36"
       class="ml-5"
     >
       <v-img


### PR DESCRIPTION
- Reduce avatar size in AppToolbar from 48px to 36px

Closes #218 