### PR TITLE
feat: #272 add subscription and card remove confirmation modals

### DIFF
--- a/components/modals/ModalConfirm/index.vue
+++ b/components/modals/ModalConfirm/index.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-dialog
+    :value="isOpen"
+    max-width="480"
+    @input="setIsOpen"
+  >
+    <form
+      @submit.prevent="onConfirm"
+    >
+      <v-card>
+        <v-card-title class="headline">
+          Are you sure?
+        </v-card-title>
+
+        <v-card-text
+          v-if="$scopedSlots.message"
+          class="pb-5"
+        >
+          <slot name="message" />
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions>
+          <v-btn
+            color="primary"
+            text
+            @click="onCancel"
+          >
+            Cancel
+          </v-btn>
+
+          <v-spacer />
+
+          <v-btn
+            color="primary"
+            type="submit"
+            text
+          >
+            Confirm
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'ModalConfirm',
+
+  props: {
+    isOpen: {
+      type: Boolean,
+      default: false
+    }
+  },
+  methods: {
+    setIsOpen (value = false) {
+      this.$emit('update:is-open', value)
+    },
+
+    onCancel () {
+      this.setIsOpen(false)
+    },
+
+    onConfirm () {
+      this.$emit('confirm')
+
+      this.setIsOpen(false)
+    }
+  }
+}
+</script>

--- a/components/sections/payment/PaymentMethodDetails/index.vue
+++ b/components/sections/payment/PaymentMethodDetails/index.vue
@@ -39,7 +39,7 @@
             <v-btn
               :loading="loading.payment"
               small
-              @click="onRemovePaymentMethod"
+              @click="onRemovePaymentMethodConfirm"
             >
               <v-icon class="mr-1">
                 mdi-delete
@@ -142,7 +142,7 @@
                 :loading="loading.subscription"
                 width="210px"
                 small
-                @click="onSubscriptionCancel"
+                @click="subscriptionCancelConfirm"
               >
                 <v-icon class="mr-1">
                   mdi-delete
@@ -185,16 +185,39 @@
           </div>
         </v-card-text>
       </v-card>
+
+      <modal-confirm
+        :is-open.sync="isOpenSubscriptionCancel"
+        @confirm="onSubscriptionCancel"
+      >
+        <template #message>
+          You are about to cancel your subscription.
+        </template>
+      </modal-confirm>
+
+      <modal-confirm
+        :is-open.sync="isOpenPaymentMethodRemove"
+        @confirm="onRemovePaymentMethod"
+      >
+        <template #message>
+          You are about to remove your payment method.
+        </template>
+      </modal-confirm>
     </a-column>
   </v-row>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
-import { initStripeCardWidget } from '@/components/sections/payment/subscription-helpers'
+import { initStripeCardWidget } from '~/components/sections/payment/subscription-helpers'
+import ModalConfirm from '~/components/modals/ModalConfirm'
 
 export default {
   name: 'PaymentMethodDetails',
+
+  components: {
+    ModalConfirm
+  },
 
   props: {
     paymentDetails: {
@@ -221,7 +244,10 @@ export default {
       planSelected: {},
 
       stripeClient: null,
-      stripeCardField: null
+      stripeCardField: null,
+
+      isOpenSubscriptionCancel: false,
+      isOpenPaymentMethodRemove: false
     }
   },
 
@@ -362,8 +388,16 @@ export default {
       this.planSelected = plan
     },
 
+    onRemovePaymentMethodConfirm () {
+      this.isOpenPaymentMethodRemove = true
+    },
+
     onRemovePaymentMethod () {
       this.$emit('payment-method:remove')
+    },
+
+    subscriptionCancelConfirm () {
+      this.isOpenSubscriptionCancel = true
     },
 
     onSubscriptionCancel () {


### PR DESCRIPTION
- Add confirmation modal component
- Apply confirmation modal on payment page before subscription cancel and payment method removal

Closes #272 